### PR TITLE
update & fix bspwm block

### DIFF
--- a/lib/barr/blocks/bspwm.rb
+++ b/lib/barr/blocks/bspwm.rb
@@ -61,7 +61,7 @@ module Barr
       end
       
       def first_monitor
-        bsp_tree["primaryMonitorName"]
+          bsp_tree["monitors"].find {|monitor| monitor["id"] == bsp_tree["primaryMonitorId"]}["name"]
       end
 
       def sys_cmd

--- a/lib/barr/blocks/bspwm.rb
+++ b/lib/barr/blocks/bspwm.rb
@@ -22,9 +22,9 @@ module Barr
         
         bsp_tree["monitors"].each do |monitor|
           next if monitor["name"] != @monitor
-          focused = monitor["focusedDesktopName"]
+          focused = monitor["focusedDesktopId"]
           monitor["desktops"].each do |desktop|
-            if desktop["name"] == focused
+            if desktop["id"] == focused
               op << focused_desktop(desktop)
             else
               op << unfocused_desktop(desktop)

--- a/spec/mocks/bspwm.rb
+++ b/spec/mocks/bspwm.rb
@@ -1,8 +1,8 @@
 
 $bsp_json = <<EOF
 {
-  "focusedMonitorName":"DP-4",
-  "primaryMonitorName":"DP-4",
+  "focusedMonitorId": 8388610,
+  "primaryMonitorId": 8388610,
   "clientsCount":8,
   "monitors":[
     {
@@ -25,7 +25,7 @@ $bsp_json = <<EOF
         "width":3840,
         "height":2160
       },
-      "focusedDesktopName":"I",
+      "focusedDesktopId": 8388612,
       "desktops":[
         {
           "name":"I",
@@ -666,953 +666,953 @@ $bsp_json = <<EOF
   ],
   "focusHistory":[
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":18874378
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":20971530
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":23068807
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"II",
+      "monitorId": 8388610,
+      "desktopId": 8388613,
       "nodeId":0
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"II",
+      "monitorId": 8388610,
+      "desktopId": 8388613,
       "nodeId":35651591
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"II",
+      "monitorId": 8388610,
+      "desktopId": 8388613,
       "nodeId":37748746
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":23068807
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":20971530
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"II",
+      "monitorId": 8388610,
+      "desktopId": 8388613,
       "nodeId":37748746
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"II",
+      "monitorId": 8388610,
+      "desktopId": 8388613,
       "nodeId":35651591
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":20971530
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"II",
+      "monitorId": 8388610,
+      "desktopId": 8388613,
       "nodeId":35651591
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"III",
+      "monitorId": 8388610,
+      "desktopId": 8388614,
       "nodeId":0
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"III",
+      "monitorId": 8388610,
+      "desktopId": 8388614,
       "nodeId":39845892
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"II",
+      "monitorId": 8388610,
+      "desktopId": 8388613,
       "nodeId":35651591
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"III",
+      "monitorId": 8388610,
+      "desktopId": 8388614,
       "nodeId":39845892
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"II",
+      "monitorId": 8388610,
+      "desktopId": 8388613,
       "nodeId":35651591
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":18874378
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":20971530
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":23068807
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"II",
+      "monitorId": 8388610,
+      "desktopId": 8388613,
       "nodeId":35651591
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":23068807
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"II",
+      "monitorId": 8388610,
+      "desktopId": 8388613,
       "nodeId":35651591
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"III",
+      "monitorId": 8388610,
+      "desktopId": 8388614,
       "nodeId":39845892
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"II",
+      "monitorId": 8388610,
+      "desktopId": 8388613,
       "nodeId":35651591
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"III",
+      "monitorId": 8388610,
+      "desktopId": 8388614,
       "nodeId":39845892
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"II",
+      "monitorId": 8388610,
+      "desktopId": 8388613,
       "nodeId":35651591
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"III",
+      "monitorId": 8388610,
+      "desktopId": 8388614,
       "nodeId":39845892
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"II",
+      "monitorId": 8388610,
+      "desktopId": 8388613,
       "nodeId":35651591
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":23068807
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"III",
+      "monitorId": 8388610,
+      "desktopId": 8388614,
       "nodeId":39845892
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"IV",
+      "monitorId": 8388610,
+      "desktopId": 8388615,
       "nodeId":0
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"IV",
+      "monitorId": 8388610,
+      "desktopId": 8388615,
       "nodeId":41943175
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":23068807
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"IX",
+      "monitorId": 8388610,
+      "desktopId": 8388620,
       "nodeId":0
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"II",
+      "monitorId": 8388610,
+      "desktopId": 8388613,
       "nodeId":35651591
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"III",
+      "monitorId": 8388610,
+      "desktopId": 8388614,
       "nodeId":39845892
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"IV",
+      "monitorId": 8388610,
+      "desktopId": 8388615,
       "nodeId":41943175
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":23068807
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":18874378
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"II",
+      "monitorId": 8388610,
+      "desktopId": 8388613,
       "nodeId":35651591
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"III",
+      "monitorId": 8388610,
+      "desktopId": 8388614,
       "nodeId":39845892
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"IV",
+      "monitorId": 8388610,
+      "desktopId": 8388615,
       "nodeId":41943175
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":18874378
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":23068807
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":20971530
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":23068807
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":20971530
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"III",
+      "monitorId": 8388610,
+      "desktopId": 8388614,
       "nodeId":39845892
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"IV",
+      "monitorId": 8388610,
+      "desktopId": 8388615,
       "nodeId":41943175
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":20971530
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":23068807
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":18874378
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":23068807
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":18874378
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":23068807
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":18874378
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":23068807
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":18874378
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":23068807
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":18874378
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":23068807
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"II",
+      "monitorId": 8388610,
+      "desktopId": 8388613,
       "nodeId":35651591
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":23068807
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":18874378
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":23068807
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":18874378
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"II",
+      "monitorId": 8388610,
+      "desktopId": 8388613,
       "nodeId":35651591
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":18874378
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":23068807
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":18874378
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":23068807
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":18874378
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"II",
+      "monitorId": 8388610,
+      "desktopId": 8388613,
       "nodeId":35651591
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":18874378
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":23068807
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"II",
+      "monitorId": 8388610,
+      "desktopId": 8388613,
       "nodeId":35651591
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":23068807
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":18874378
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"II",
+      "monitorId": 8388610,
+      "desktopId": 8388613,
       "nodeId":35651591
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":18874378
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":23068807
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":18874378
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":23068807
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":18874378
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":23068807
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":18874378
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"VIII",
+      "monitorId": 8388610,
+      "desktopId": 8388619,
       "nodeId":0
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":18874378
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"V",
+      "monitorId": 8388610,
+      "desktopId": 8388616,
       "nodeId":0
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"IX",
+      "monitorId": 8388610,
+      "desktopId": 8388620,
       "nodeId":0
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":18874378
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":23068807
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":18874378
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"II",
+      "monitorId": 8388610,
+      "desktopId": 8388613,
       "nodeId":35651591
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":18874378
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"VI",
+      "monitorId": 8388610,
+      "desktopId": 8388617,
       "nodeId":0
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"VIII",
+      "monitorId": 8388610,
+      "desktopId": 8388619,
       "nodeId":0
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"II",
+      "monitorId": 8388610,
+      "desktopId": 8388613,
       "nodeId":35651591
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":18874378
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"VIII",
+      "monitorId": 8388610,
+      "desktopId": 8388619,
       "nodeId":0
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"VI",
+      "monitorId": 8388610,
+      "desktopId": 8388617,
       "nodeId":0
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"IX",
+      "monitorId": 8388610,
+      "desktopId": 8388620,
       "nodeId":0
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":18874378
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"IV",
+      "monitorId": 8388610,
+      "desktopId": 8388615,
       "nodeId":41943175
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"V",
+      "monitorId": 8388610,
+      "desktopId": 8388616,
       "nodeId":0
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"VIII",
+      "monitorId": 8388610,
+      "desktopId": 8388619,
       "nodeId":0
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":18874378
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":23068807
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":18874378
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":23068807
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"II",
+      "monitorId": 8388610,
+      "desktopId": 8388613,
       "nodeId":35651591
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"III",
+      "monitorId": 8388610,
+      "desktopId": 8388614,
       "nodeId":39845892
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":23068807
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"VIII",
+      "monitorId": 8388610,
+      "desktopId": 8388619,
       "nodeId":0
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"II",
+      "monitorId": 8388610,
+      "desktopId": 8388613,
       "nodeId":35651591
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"III",
+      "monitorId": 8388610,
+      "desktopId": 8388614,
       "nodeId":39845892
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"II",
+      "monitorId": 8388610,
+      "desktopId": 8388613,
       "nodeId":35651591
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"III",
+      "monitorId": 8388610,
+      "desktopId": 8388614,
       "nodeId":39845892
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":23068807
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":18874378
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":20971530
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":18874378
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":20971530
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":18874378
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":20971530
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"II",
+      "monitorId": 8388610,
+      "desktopId": 8388613,
       "nodeId":35651591
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"III",
+      "monitorId": 8388610,
+      "desktopId": 8388614,
       "nodeId":39845892
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"IV",
+      "monitorId": 8388610,
+      "desktopId": 8388615,
       "nodeId":41943175
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":20971530
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"II",
+      "monitorId": 8388610,
+      "desktopId": 8388613,
       "nodeId":35651591
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"III",
+      "monitorId": 8388610,
+      "desktopId": 8388614,
       "nodeId":39845892
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"IV",
+      "monitorId": 8388610,
+      "desktopId": 8388615,
       "nodeId":41943175
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"IX",
+      "monitorId": 8388610,
+      "desktopId": 8388620,
       "nodeId":0
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":20971530
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"II",
+      "monitorId": 8388610,
+      "desktopId": 8388613,
       "nodeId":35651591
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"III",
+      "monitorId": 8388610,
+      "desktopId": 8388614,
       "nodeId":39845892
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"IV",
+      "monitorId": 8388610,
+      "desktopId": 8388615,
       "nodeId":41943175
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"IV",
+      "monitorId": 8388610,
+      "desktopId": 8388615,
       "nodeId":25165825
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":20971530
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":23068807
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":18874378
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":23068807
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":18874378
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":23068807
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"II",
+      "monitorId": 8388610,
+      "desktopId": 8388613,
       "nodeId":35651591
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"III",
+      "monitorId": 8388610,
+      "desktopId": 8388614,
       "nodeId":39845892
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"IV",
+      "monitorId": 8388610,
+      "desktopId": 8388615,
       "nodeId":25165825
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"II",
+      "monitorId": 8388610,
+      "desktopId": 8388613,
       "nodeId":35651591
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"III",
+      "monitorId": 8388610,
+      "desktopId": 8388614,
       "nodeId":39845892
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":23068807
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"II",
+      "monitorId": 8388610,
+      "desktopId": 8388613,
       "nodeId":35651591
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"III",
+      "monitorId": 8388610,
+      "desktopId": 8388614,
       "nodeId":39845892
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":23068807
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"II",
+      "monitorId": 8388610,
+      "desktopId": 8388613,
       "nodeId":35651591
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":23068807
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"II",
+      "monitorId": 8388610,
+      "desktopId": 8388613,
       "nodeId":35651591
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"III",
+      "monitorId": 8388610,
+      "desktopId": 8388614,
       "nodeId":39845892
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"IV",
+      "monitorId": 8388610,
+      "desktopId": 8388615,
       "nodeId":25165825
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"II",
+      "monitorId": 8388610,
+      "desktopId": 8388613,
       "nodeId":35651591
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"III",
+      "monitorId": 8388610,
+      "desktopId": 8388614,
       "nodeId":39845892
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":23068807
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"II",
+      "monitorId": 8388610,
+      "desktopId": 8388613,
       "nodeId":35651591
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"III",
+      "monitorId": 8388610,
+      "desktopId": 8388614,
       "nodeId":39845892
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"IV",
+      "monitorId": 8388610,
+      "desktopId": 8388615,
       "nodeId":25165825
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"II",
+      "monitorId": 8388610,
+      "desktopId": 8388613,
       "nodeId":35651591
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":23068807
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"II",
+      "monitorId": 8388610,
+      "desktopId": 8388613,
       "nodeId":35651591
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"III",
+      "monitorId": 8388610,
+      "desktopId": 8388614,
       "nodeId":39845892
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"IV",
+      "monitorId": 8388610,
+      "desktopId": 8388615,
       "nodeId":25165825
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"IV",
+      "monitorId": 8388610,
+      "desktopId": 8388615,
       "nodeId":41943175
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":23068807
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"II",
+      "monitorId": 8388610,
+      "desktopId": 8388613,
       "nodeId":35651591
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"III",
+      "monitorId": 8388610,
+      "desktopId": 8388614,
       "nodeId":39845892
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"II",
+      "monitorId": 8388610,
+      "desktopId": 8388613,
       "nodeId":35651591
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":23068807
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":20971530
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":18874378
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":20971530
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"II",
+      "monitorId": 8388610,
+      "desktopId": 8388613,
       "nodeId":35651591
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"III",
+      "monitorId": 8388610,
+      "desktopId": 8388614,
       "nodeId":39845892
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":20971530
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":23068807
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"II",
+      "monitorId": 8388610,
+      "desktopId": 8388613,
       "nodeId":35651591
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"III",
+      "monitorId": 8388610,
+      "desktopId": 8388614,
       "nodeId":39845892
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"II",
+      "monitorId": 8388610,
+      "desktopId": 8388613,
       "nodeId":35651591
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":23068807
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":18874378
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":23068807
     },
     {
-      "monitorName":"DP-4",
-      "desktopName":"I",
+      "monitorId": 8388610,
+      "desktopId": 8388612,
       "nodeId":18874378
     }
   ],


### PR DESCRIPTION
bspwm JSON format has changed and bspwm block does not detect focused desktop properly. There was already an attempt to fix this(see #31), but that does not fix issue with primary monitor detection and travis didn't pass on the PR.

I updated the mock json string used by tests to reflect what is returned by bspwm 0.9.2 and then fixed the block so that all tests are passing again.

It's worth to mention I'm currently running this version of gem on my bspwm 0.9.2 desktop just fine.

P.S. Thanks for this project, I love configuring lemonbar via ruby :)